### PR TITLE
1차 내부 QA 반영

### DIFF
--- a/src/components/atoms/input/MiniSelectBox.tsx
+++ b/src/components/atoms/input/MiniSelectBox.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 
 import { cn } from '@/utils/cn';
 
@@ -21,6 +21,13 @@ interface IMiniSelectProps {
 
 const MiniSelectBox: React.FC<IMiniSelectProps> = ({ className, list, value, onChange }) => {
   const [isOpen, setIsOpen] = useState(false);
+  const [width, setWidth] = useState(0);
+
+  const measuredRef = useCallback((node: HTMLDivElement | null) => {
+    if (node) {
+      setWidth(node.getBoundingClientRect().width);
+    }
+  }, []);
 
   const toggleIsOpen = () => setIsOpen((prev) => !prev);
 
@@ -32,42 +39,42 @@ const MiniSelectBox: React.FC<IMiniSelectProps> = ({ className, list, value, onC
   const rotateClass = isOpen ? '' : 'rotate-180';
 
   return (
-    <div
-      className={cn(
-        'transition-all-3 w-fit overflow-hidden rounded-[10px] border border-grey07 bg-white01 text-sm leading-none',
-        isOpen ? 'max-h-[160px]' : 'max-h-[34px]',
-        className,
-      )}
-    >
+    <div style={{ width }} className={cn('relative h-[34px]', className)}>
       <div
-        onClick={toggleIsOpen}
-        className="flex h-8 cursor-pointer items-center justify-between gap-2 px-2"
+        ref={measuredRef}
+        className={cn(
+          'transition-all-3 absolute left-0 top-0 w-fit overflow-hidden rounded-[10px] border border-grey07 bg-white01 text-sm leading-none',
+          isOpen ? 'max-h-[160px]' : 'max-h-[34px]',
+        )}
       >
-        <Text fontSize={14} color="black01" className="leading-none">
-          {value.title}
-        </Text>
-
-        <BoxIcon
-          name="chevron-up"
-          class={cn(rotateClass, 'transition-transform duration-300')}
-          color="grey05"
-        />
-      </div>
-
-      <div className="flex flex-col">
-        {list
-          .filter((option) => option.id !== value.id)
-          .map((option) => (
-            <div
-              key={option.id}
-              className="flex h-8 cursor-pointer items-center px-2 hover:bg-grey08"
-              onClick={() => handleSelect(option)}
-            >
-              <Text fontSize={14} color="grey01" className="leading-none">
-                {option.title}
-              </Text>
-            </div>
-          ))}
+        <div
+          onClick={toggleIsOpen}
+          className="flex h-8 cursor-pointer items-center justify-between gap-2 px-2"
+        >
+          <Text fontSize={14} color="black01" className="leading-none">
+            {value.title}
+          </Text>
+          <BoxIcon
+            name="chevron-up"
+            class={cn(rotateClass, 'transition-transform duration-300')}
+            color="grey05"
+          />
+        </div>
+        <div className="flex flex-col">
+          {list
+            .filter((option) => option.id !== value.id)
+            .map((option) => (
+              <div
+                key={option.id}
+                className="flex h-8 cursor-pointer items-center px-2 hover:bg-grey08"
+                onClick={() => handleSelect(option)}
+              >
+                <Text fontSize={14} color="grey01" className="leading-none">
+                  {option.title}
+                </Text>
+              </div>
+            ))}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
- 최신순, 인기순 클릭 시 화면 전체 늘어남 → 픽스된 상태로 열리게
(화면 전체가 늘어나지 않도록 absolute로 변경해주었습니다. 0px이 되어버린 relative node의 width는 ref를 이용하여 set)