### PR TITLE
refactor: query key 리팩토링

### DIFF
--- a/src/app/(auth)/link/social/[provider]/page.tsx
+++ b/src/app/(auth)/link/social/[provider]/page.tsx
@@ -6,7 +6,7 @@ import { useParams, useRouter, useSearchParams } from 'next/navigation';
 
 import LoadingSpinner from '@/components/atoms/loading/LoadingSpinner';
 import { Text } from '@/components/atoms/text/Text';
-import { USER_INFO_QUERY_KEY } from '@/constants/query-key.constants';
+import { USER_QUERY_KEY } from '@/constants/query-key.constants';
 import { useSocialLink } from '@/hooks/queries/auth.hooks';
 import { showErrorToast } from '@/utils/functions';
 
@@ -22,7 +22,7 @@ const SocialLinkContent = () => {
   const { mutate: socialLink } = useSocialLink({
     onSuccess: (res) => {
       if (res.status === 200) {
-        queryClient.removeQueries({ queryKey: [USER_INFO_QUERY_KEY] });
+        queryClient.removeQueries({ queryKey: USER_QUERY_KEY.INFO() });
 
         router.push(`/my/edit`);
       }

--- a/src/app/(services)/feed/add-log/@form/log-form.tsx
+++ b/src/app/(services)/feed/add-log/@form/log-form.tsx
@@ -9,23 +9,23 @@ import { useRouter } from 'next/navigation';
 import Button from '@/components/atoms/button/Button';
 import RecipeImageInput from '@/components/atoms/input/RecipeImageInput';
 import TextArea from '@/components/atoms/input/TextArea';
-import { FEED_LIST_QUERY_KEY, FEED_QUERY_KEY } from '@/constants/query-key.constants';
+import { FEED_QUERY_KEY } from '@/constants/query-key.constants';
 import { useAddLog, useEditLog, useGetLog } from '@/hooks/queries/feed.hooks';
 import { zodAddLog } from '@/lib/zod/zodValidation';
 import { TAddLogFormData } from '@/types/api';
 import { showToast } from '@/utils/functions';
 
 interface ILogFormProps {
-  id?: number;
+  logId?: number;
 }
 
-const LogForm = ({ id }: ILogFormProps) => {
+const LogForm = ({ logId }: ILogFormProps) => {
   const router = useRouter();
   const queryClient = useQueryClient();
 
   const [imageRequired, setImageRequired] = useState(false);
 
-  const { data: logData } = useGetLog(Number(id || -1));
+  const { data: logData } = useGetLog(logId ?? -1);
 
   const {
     register,
@@ -55,7 +55,7 @@ const LogForm = ({ id }: ILogFormProps) => {
     onSuccess: (res) => {
       if (res.status === 201) {
         router.push('/feed');
-        queryClient.invalidateQueries({ queryKey: [FEED_LIST_QUERY_KEY] });
+        queryClient.invalidateQueries({ queryKey: FEED_QUERY_KEY.LIST() });
         showToast({ message: '일기 작성 완료!', type: 'success' });
       }
     },
@@ -70,8 +70,8 @@ const LogForm = ({ id }: ILogFormProps) => {
     onSuccess: (res) => {
       if (res.status === 200) {
         router.push('/feed');
-        queryClient.invalidateQueries({ queryKey: [FEED_LIST_QUERY_KEY] });
-        queryClient.invalidateQueries({ queryKey: [FEED_QUERY_KEY, id] });
+        queryClient.invalidateQueries({ queryKey: FEED_QUERY_KEY.LIST() });
+        queryClient.invalidateQueries({ queryKey: FEED_QUERY_KEY.DETAIL(logId ?? -1) });
         showToast({ message: '일기 수정 완료!', type: 'success' });
       }
     },
@@ -102,7 +102,7 @@ const LogForm = ({ id }: ILogFormProps) => {
         formData.append('multipartFiles', imageFile);
       });
 
-    if (id) editLog({ id, formData });
+    if (logId) editLog({ logId, formData });
     else addLog(formData);
   };
 
@@ -121,7 +121,7 @@ const LogForm = ({ id }: ILogFormProps) => {
 
       <div className="mt-24">
         <Button full type="submit">
-          {id ? '수정하기' : '작성하기'}
+          {logId ? '수정하기' : '작성하기'}
         </Button>
       </div>
     </form>

--- a/src/app/(services)/feed/comment/[id]/@item/feed-comment-list.tsx
+++ b/src/app/(services)/feed/comment/[id]/@item/feed-comment-list.tsx
@@ -24,7 +24,7 @@ const FeedCommentList = ({
     hasNextPage,
     fetchNextPage,
     isFetchingNextPage,
-  } = useGetCommentList(Number(id));
+  } = useGetCommentList(id);
 
   return (
     <div>

--- a/src/app/(services)/feed/comment/[id]/@item/feed-detail.tsx
+++ b/src/app/(services)/feed/comment/[id]/@item/feed-detail.tsx
@@ -17,7 +17,7 @@ const FeedItem = dynamic(() => import('../../../feed-item'), {
 
 const FeedDetail = ({ id }: { id: number }) => {
   const { data: userData } = useGetUserInfo();
-  const { data: logDetail } = useGetLog(Number(id));
+  const { data: logDetail } = useGetLog(id);
 
   const { setLogId, isReply, setIsReply, contentRefs, handleDelete, commentId, setCommentId } =
     useFeedDetailActions();

--- a/src/app/(services)/feed/edit-log/[id]/page.tsx
+++ b/src/app/(services)/feed/edit-log/[id]/page.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import PageHeader from '@/components/atoms/page-header/PageHeader';
 
 import LogForm from '../../add-log/@form/log-form';
@@ -11,7 +9,7 @@ const page = async ({ params }: { params: Promise<{ id: string }> }) => {
     <div>
       <PageHeader title="일기 작성" back backUrl="/feed" />
 
-      <LogForm id={Number(id)} />
+      <LogForm logId={Number(id)} />
     </div>
   );
 };

--- a/src/app/(services)/feed/feed-item.tsx
+++ b/src/app/(services)/feed/feed-item.tsx
@@ -63,7 +63,7 @@ const FeedItem = ({ log, isMyPost, contentRefs, setLogId, isDetail }: IFeedItemP
       if (res.status === 201) {
         try {
           ToggleLikeSuccess(log, queryClient);
-          queryClient.invalidateQueries({ queryKey: [FEED_QUERY_KEY, Number(log.id)] });
+          queryClient.invalidateQueries({ queryKey: FEED_QUERY_KEY.DETAIL(log.id) });
         } catch (error) {
           console.error('ToggleLikeSuccess error:', error);
         }
@@ -76,7 +76,7 @@ const FeedItem = ({ log, isMyPost, contentRefs, setLogId, isDetail }: IFeedItemP
       if (res.status === 200) {
         try {
           ToggleLikeSuccess(log, queryClient);
-          queryClient.invalidateQueries({ queryKey: [FEED_QUERY_KEY, Number(log.id)] });
+          queryClient.invalidateQueries({ queryKey: FEED_QUERY_KEY.DETAIL(log.id) });
         } catch (error) {
           console.error('ToggleLikeSuccess error:', error);
         }
@@ -107,7 +107,7 @@ const FeedItem = ({ log, isMyPost, contentRefs, setLogId, isDetail }: IFeedItemP
       switch (type) {
         case '삭제하기':
           handleOpenModal(DELETE_FEED_MODAL);
-          setLogId(Number(log.id));
+          setLogId(log.id);
           break;
         case '수정하기':
           router.push(`/feed/edit-log/${log.id}`);

--- a/src/app/(services)/feed/feed-list.tsx
+++ b/src/app/(services)/feed/feed-list.tsx
@@ -3,7 +3,7 @@ import dynamic from 'next/dynamic';
 
 import DeleteFeedModal from '@/components/molecules/feed/DeleteFeedModal';
 import InfiniteScroll from '@/components/organisms/infinite-scroll/InfiniteScroll';
-import { FEED_LIST_QUERY_KEY } from '@/constants/query-key.constants';
+import { FEED_QUERY_KEY } from '@/constants/query-key.constants';
 import { useGetLogList } from '@/hooks/queries/feed.hooks';
 import { useFeedItemActions } from '@/hooks/useFeedItemActions';
 import useScrollPosition from '@/hooks/useScrollPosition';
@@ -20,7 +20,7 @@ const FeedList = () => {
 
   // 스크롤 위치 저장 (뒤로가기시 해당 위치로 이동)
   useScrollPosition({
-    storageKey: `${FEED_LIST_QUERY_KEY}-scroll`,
+    storageKey: `${FEED_QUERY_KEY.LIST()}-scroll`,
     shouldRestore: !isFetching,
   });
 

--- a/src/app/(services)/my/certificate/page.tsx
+++ b/src/app/(services)/my/certificate/page.tsx
@@ -7,7 +7,7 @@ import Link from 'next/link';
 import Button from '@/components/atoms/button/Button';
 import PageHeader from '@/components/atoms/page-header/PageHeader';
 import BottomSheet from '@/components/organisms/bottom-sheet/BottomSheet';
-import { LICENSE_COUNT_QUERY_KEY } from '@/constants/query-key.constants';
+import { USER_QUERY_KEY } from '@/constants/query-key.constants';
 import {
   useGetLicenseCount,
   useGetLicenseList,
@@ -27,7 +27,7 @@ const CertificatePage = () => {
   const { mutate: uploadLicense } = useUploadLicense({
     onSuccess: (res) => {
       if (res.status === 201) {
-        queryClient.invalidateQueries({ queryKey: [LICENSE_COUNT_QUERY_KEY] });
+        queryClient.invalidateQueries({ queryKey: USER_QUERY_KEY.LICENSE_COUNT() });
         showToast({ message: '등록되었습니다.', type: 'success' });
       }
     },

--- a/src/app/(services)/my/edit/@form/edit-form.tsx
+++ b/src/app/(services)/my/edit/@form/edit-form.tsx
@@ -11,7 +11,7 @@ import TextInput from '@/components/atoms/input/TextInput';
 import { Text } from '@/components/atoms/text/Text';
 import { CheckEmailInput, CheckNicknameInput } from '@/components/molecules/input/DuplicateCheck';
 import { ERROR_CODE_MESSAGE_MAP } from '@/constants/error-message.constants';
-import { USER_INFO_QUERY_KEY } from '@/constants/query-key.constants';
+import { USER_QUERY_KEY } from '@/constants/query-key.constants';
 import { useUpdateUserInfo } from '@/hooks/queries/auth.hooks';
 import { zodEmailUserInfo, zodSocialUserInfo } from '@/lib/zod/zodValidation';
 import { TUserData, TUserInfoEditFormValues } from '@/types/api';
@@ -62,7 +62,7 @@ const UserInfoEditForm = ({ imageFile, userData }: IUserInfoEditForm) => {
   const { mutate: updateUserInfo } = useUpdateUserInfo({
     onSuccess: (res) => {
       if (res.status === 200) {
-        queryClient.invalidateQueries({ queryKey: [USER_INFO_QUERY_KEY] });
+        queryClient.invalidateQueries({ queryKey: USER_QUERY_KEY.INFO() });
         setValue('password', '');
         setValue('confirmPassword', '');
 

--- a/src/app/(services)/my/shopping-list/page.tsx
+++ b/src/app/(services)/my/shopping-list/page.tsx
@@ -12,7 +12,7 @@ import PageHeader from '@/components/atoms/page-header/PageHeader';
 import FoodsSearch from '@/components/molecules/foods-search/FoodsSearch';
 import InfiniteScroll from '@/components/organisms/infinite-scroll/InfiniteScroll';
 import { UNIT_OPTIONS } from '@/constants/options.constants';
-import { SHOPPING_LIST_QUERY_KEY } from '@/constants/query-key.constants';
+import { USER_QUERY_KEY } from '@/constants/query-key.constants';
 import {
   useAddShoppingList,
   useGetShoppingList,
@@ -33,7 +33,7 @@ const ShoppingListPage = () => {
 
   const { mutate: removeShoppingList } = useRemoveShoppingList({
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: [SHOPPING_LIST_QUERY_KEY] });
+      queryClient.invalidateQueries({ queryKey: USER_QUERY_KEY.SHOPPING_LIST() });
     },
   });
 
@@ -58,8 +58,7 @@ const ShoppingListPage = () => {
   const { mutate: addShoppingList } = useAddShoppingList({
     onSuccess: (res) => {
       if (res.status === 201) {
-        queryClient.invalidateQueries({ queryKey: [SHOPPING_LIST_QUERY_KEY] });
-        queryClient.refetchQueries({ queryKey: [SHOPPING_LIST_QUERY_KEY] });
+        queryClient.invalidateQueries({ queryKey: USER_QUERY_KEY.SHOPPING_LIST() });
         closeBottomSheet();
         reset();
       }
@@ -88,10 +87,7 @@ const ShoppingListPage = () => {
   }
 
   const onSubmit = (data: z.infer<typeof zodShoppingListForm>) => {
-    addShoppingList({
-      ...data,
-      amount: Number(data.amount),
-    });
+    addShoppingList(data);
   };
 
   return (

--- a/src/app/(services)/profile/[id]/profile-info-section.tsx
+++ b/src/app/(services)/profile/[id]/profile-info-section.tsx
@@ -25,7 +25,7 @@ interface IProfileInfoSectionProps {
 const ProfileInfoSection = ({ id }: IProfileInfoSectionProps) => {
   const router = useRouter();
 
-  const { data: profileInfo } = useGetProfileInfo(Number(id));
+  const { data: profileInfo } = useGetProfileInfo(id);
 
   const { isLoggedIn } = useLoginStore();
   const { data: userInfo } = useGetUserInfo();
@@ -69,7 +69,7 @@ const ProfileInfoSection = ({ id }: IProfileInfoSectionProps) => {
 
         <div className="flex items-center gap-2">
           {/* 채팅 아이콘 */}
-          {userInfo?.id !== Number(id) && (
+          {userInfo?.id !== id && (
             <div
               className="flex h-[30px] w-[30px] items-center justify-center rounded-full border border-primary01 px-1"
               onClick={() => {

--- a/src/app/(services)/recipe/[id]/edit/info-form.tsx
+++ b/src/app/(services)/recipe/[id]/edit/info-form.tsx
@@ -15,7 +15,7 @@ import TextArea from '@/components/atoms/input/TextArea';
 import TextInput from '@/components/atoms/input/TextInput';
 import Tooltip from '@/components/atoms/tooltip/Tooltip';
 import { COOK_TIME_OPTIONS, PRICE_OPTIONS } from '@/constants/options.constants';
-import { RECIPE_DETAIL_QUERY_KEY } from '@/constants/query-key.constants';
+import { RECIPE_QUERY_KEY } from '@/constants/query-key.constants';
 import { useGetUserInfo } from '@/hooks/queries/auth.hooks';
 import { useGetRecipeDetail, useUpdateRecipe } from '@/hooks/queries/recipe.hooks';
 import { zodEditRecipeForm } from '@/lib/zod/zodValidation';
@@ -35,7 +35,8 @@ const InfoForm = ({ recipeId }: InfoFormProps) => {
   const { mutate: updateRecipe } = useUpdateRecipe({
     onSuccess: () => {
       router.push(`/recipe/${recipeId}`);
-      queryClient.invalidateQueries({ queryKey: RECIPE_DETAIL_QUERY_KEY(recipeId) });
+      queryClient.invalidateQueries({ queryKey: RECIPE_QUERY_KEY.LIST() });
+      queryClient.invalidateQueries({ queryKey: RECIPE_QUERY_KEY.DETAIL(recipeId) });
       showToast({ message: '레시피 수정 완료!', type: 'success' });
     },
   });

--- a/src/app/(services)/recipe/[id]/ingredient.tsx
+++ b/src/app/(services)/recipe/[id]/ingredient.tsx
@@ -56,6 +56,7 @@ const Ingredient = ({ recipeId }: IngredientProps) => {
                     {recipeFoodUnit} · {cal * servingNumber}kcal
                   </div>
                   <ShoppingButton
+                    recipeId={recipeId}
                     foodId={foodId}
                     amount={amount}
                     foodUnit={recipeFoodUnit}

--- a/src/app/(services)/recipe/[id]/memo-button.tsx
+++ b/src/app/(services)/recipe/[id]/memo-button.tsx
@@ -9,7 +9,7 @@ import Button from '@/components/atoms/button/Button';
 import { BoxIcon } from '@/components/atoms/icon/BoxIcon';
 import TextArea from '@/components/atoms/input/TextArea';
 import BottomSheet from '@/components/organisms/bottom-sheet/BottomSheet';
-import { RECIPE_MEMO_QUERY_KEY } from '@/constants/query-key.constants';
+import { RECIPE_QUERY_KEY } from '@/constants/query-key.constants';
 import {
   useAddRecipeMemo,
   useGetRecipeMemo,
@@ -27,14 +27,14 @@ const MemoButton = ({ recipeId }: MemoButtonProps) => {
   const { data: recipeMemo, isPending, isError, error } = useGetRecipeMemo({ recipeId });
   const { mutate: addMemo } = useAddRecipeMemo({
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: RECIPE_MEMO_QUERY_KEY(recipeId) });
+      queryClient.invalidateQueries({ queryKey: RECIPE_QUERY_KEY.MEMO(recipeId) });
       setBottomSheetOpen(false);
     },
     onError: () => showToast({ message: '레시피 메모 등록 중 오류가 발생했어요', type: 'error' }),
   });
   const { mutate: updateMemo } = useUpdateRecipeMemo({
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: RECIPE_MEMO_QUERY_KEY(recipeId) });
+      queryClient.invalidateQueries({ queryKey: RECIPE_QUERY_KEY.MEMO(recipeId) });
       setBottomSheetOpen(false);
     },
     onError: () => showToast({ message: '레시피 메모 수정 중 오류가 발생했어요', type: 'error' }),

--- a/src/app/(services)/recipe/[id]/page.tsx
+++ b/src/app/(services)/recipe/[id]/page.tsx
@@ -10,7 +10,7 @@ import LoadingSpinner from '@/components/atoms/loading/LoadingSpinner';
 import Popup from '@/components/molecules/popup/Popup';
 import { ERecipeDetailSection } from '@/constants/common.constants';
 import { PAY_RECIPE_MODAL } from '@/constants/modal.constants';
-import { RECIPE_DETAIL_QUERY_KEY } from '@/constants/query-key.constants';
+import { RECIPE_QUERY_KEY } from '@/constants/query-key.constants';
 import { useGetRecipeDetail, usePayRecipe } from '@/hooks/queries/recipe.hooks';
 import { handleOpenModal } from '@/utils/functions';
 
@@ -26,7 +26,7 @@ const RecipeDetailContent = ({ params }: { params: Promise<{ id: string }> }) =>
   });
   const { mutate: payRecipe } = usePayRecipe({
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: RECIPE_DETAIL_QUERY_KEY(recipeId) });
+      queryClient.invalidateQueries({ queryKey: RECIPE_QUERY_KEY.DETAIL(recipeId) });
     },
   });
   const searchParams = useSearchParams();

--- a/src/app/(services)/recipe/[id]/recipe-header.tsx
+++ b/src/app/(services)/recipe/[id]/recipe-header.tsx
@@ -18,7 +18,7 @@ import { ERecipeDetailSection } from '@/constants/common.constants';
 import { CHAT_ROOM_URL } from '@/constants/endpoint.constants';
 import { DELETE_RECIPE_MODAL } from '@/constants/modal.constants';
 import { RECIPE_MY_OPTIONS, RECIPE_OPTIONS } from '@/constants/options.constants';
-import { RECIPE_LIST_QUERY_KEY } from '@/constants/query-key.constants';
+import { RECIPE_QUERY_KEY } from '@/constants/query-key.constants';
 import { useGetUserInfo } from '@/hooks/queries/auth.hooks';
 import { useDeleteRecipe } from '@/hooks/queries/recipe.hooks';
 import { useReport } from '@/hooks/queries/report.hooks';
@@ -55,7 +55,7 @@ const RecipeHeaderContent = ({ recipeId, authorId, isMyRecipe = false }: RecipeH
   const { mutate: deleteRecipe } = useDeleteRecipe({
     onSuccess: () => {
       router.push('/recipe');
-      queryClient.invalidateQueries({ queryKey: RECIPE_LIST_QUERY_KEY });
+      queryClient.invalidateQueries({ queryKey: RECIPE_QUERY_KEY.LIST() });
       showToast({ message: '레시피 삭제 완료!', type: 'success' });
     },
   });

--- a/src/app/(services)/recipe/[id]/review/[reviewId]/page.tsx
+++ b/src/app/(services)/recipe/[id]/review/[reviewId]/page.tsx
@@ -9,7 +9,7 @@ import Button from '@/components/atoms/button/Button';
 import PageHeader from '@/components/atoms/page-header/PageHeader';
 import Popup from '@/components/molecules/popup/Popup';
 import { DELETE_REVIEW_MODAL } from '@/constants/modal.constants';
-import { MY_RECIPE_REVIEW_LIST_QUERY_KEY } from '@/constants/query-key.constants';
+import { RECIPE_QUERY_KEY } from '@/constants/query-key.constants';
 import {
   useDeleteRecipeReview,
   useGetRecipeDetail,
@@ -42,7 +42,7 @@ const ReviewDetailPage = ({ params }: { params: Promise<{ id: string }> }) => {
         const modal = document.getElementById(DELETE_REVIEW_MODAL) as HTMLDialogElement;
         modal.close();
         showToast({ message: '리뷰를 삭제했습니다.', type: 'success' });
-        queryClient.invalidateQueries({ queryKey: [MY_RECIPE_REVIEW_LIST_QUERY_KEY] });
+        queryClient.invalidateQueries({ queryKey: RECIPE_QUERY_KEY.REVIEW_LIST() });
         router.back();
       }
     },

--- a/src/app/(services)/recipe/[id]/review/review.tsx
+++ b/src/app/(services)/recipe/[id]/review/review.tsx
@@ -12,7 +12,7 @@ import TextArea from '@/components/atoms/input/TextArea';
 import Rating from '@/components/atoms/rating/Rating';
 import { Text } from '@/components/atoms/text/Text';
 import BottomSheet from '@/components/organisms/bottom-sheet/BottomSheet';
-import { RECIPE_REVIEW_LIST_QUERY_KEY } from '@/constants/query-key.constants';
+import { RECIPE_QUERY_KEY } from '@/constants/query-key.constants';
 import { useAddReviewReply } from '@/hooks/queries/recipe.hooks';
 import { zodReviewReplyForm } from '@/lib/zod/zodValidation';
 import { IReview } from '@/types/api';
@@ -34,7 +34,7 @@ const Review = ({ review, isReply, isWriter }: ReviewProps) => {
   const { mutate: addReviewReply } = useAddReviewReply({
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: RECIPE_REVIEW_LIST_QUERY_KEY(review.recipeId),
+        queryKey: RECIPE_QUERY_KEY.REVIEW_LIST_BY_RECIPE_ID(review.recipeId),
       });
       router.push(`/recipe/${review.recipeId}/review`);
       setBottomSheetOpen(false);

--- a/src/app/(services)/recipe/[id]/review/write/page.tsx
+++ b/src/app/(services)/recipe/[id]/review/write/page.tsx
@@ -10,7 +10,7 @@ import Button from '@/components/atoms/button/Button';
 import TextArea from '@/components/atoms/input/TextArea';
 import PageHeader from '@/components/atoms/page-header/PageHeader';
 import StarRate from '@/components/molecules/star-rate/StarRate';
-import { RECIPE_REVIEW_LIST_QUERY_KEY } from '@/constants/query-key.constants';
+import { RECIPE_QUERY_KEY } from '@/constants/query-key.constants';
 import { useAddReview } from '@/hooks/queries/recipe.hooks';
 import { zodReviewForm } from '@/lib/zod/zodValidation';
 import { showToast } from '@/utils/functions';
@@ -37,7 +37,7 @@ const RecipeReviewWritePage = ({ params }: { params: Promise<{ id: string }> }) 
   const { mutate: addReview } = useAddReview({
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: RECIPE_REVIEW_LIST_QUERY_KEY(recipeId),
+        queryKey: RECIPE_QUERY_KEY.REVIEW_LIST_BY_RECIPE_ID(recipeId),
       });
       router.push(`/recipe/${recipeId}/review`);
       showToast({ message: '리뷰 등록에 성공했어요', type: 'success' });

--- a/src/app/(services)/recipe/[id]/shopping-button.tsx
+++ b/src/app/(services)/recipe/[id]/shopping-button.tsx
@@ -1,11 +1,12 @@
 import { useQueryClient } from '@tanstack/react-query';
 
 import { BoxIcon } from '@/components/atoms/icon/BoxIcon';
-import { RECIPE_INGREDIENT_QUERY_KEY } from '@/constants/query-key.constants';
+import { RECIPE_QUERY_KEY, USER_QUERY_KEY } from '@/constants/query-key.constants';
 import { useAddShoppingList, useRemoveShoppingList } from '@/hooks/queries/shopping.hooks';
 import { AddShoppingListPayload } from '@/types/api';
 
 interface ShoppingButtonProps {
+  recipeId: number;
   foodId: number;
   amount: number;
   foodUnit: string;
@@ -14,6 +15,7 @@ interface ShoppingButtonProps {
 }
 
 function ShoppingButton({
+  recipeId,
   foodId,
   amount,
   foodUnit,
@@ -25,14 +27,20 @@ function ShoppingButton({
   const { mutate: addShoppingList } = useAddShoppingList({
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: [RECIPE_INGREDIENT_QUERY_KEY],
+        queryKey: RECIPE_QUERY_KEY.INGREDIENT_LIST(recipeId),
+      });
+      queryClient.invalidateQueries({
+        queryKey: USER_QUERY_KEY.SHOPPING_LIST(),
       });
     },
   });
   const { mutate: removeShoppingList } = useRemoveShoppingList({
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: [RECIPE_INGREDIENT_QUERY_KEY],
+        queryKey: RECIPE_QUERY_KEY.INGREDIENT_LIST(recipeId),
+      });
+      queryClient.invalidateQueries({
+        queryKey: USER_QUERY_KEY.SHOPPING_LIST(),
       });
     },
   });

--- a/src/app/(services)/recipe/recipe-item.tsx
+++ b/src/app/(services)/recipe/recipe-item.tsx
@@ -12,7 +12,7 @@ import Popup from '@/components/molecules/popup/Popup';
 import RecipeInfo from '@/components/molecules/recipe-info/RecipeInfo';
 import { DELETE_RECIPE_MODAL } from '@/constants/modal.constants';
 import { RECIPE_MY_OPTIONS } from '@/constants/options.constants';
-import { RECIPE_DETAIL_QUERY_KEY, RECIPE_LIST_QUERY_KEY } from '@/constants/query-key.constants';
+import { RECIPE_QUERY_KEY } from '@/constants/query-key.constants';
 import {
   useAddBookmarkRecipe,
   useCancelBookmarkRecipe,
@@ -31,15 +31,15 @@ const RecipeItem = ({ recipe, ...props }: RecipeListProps) => {
 
   const { mutate: addBookmarkRecipe } = useAddBookmarkRecipe({
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: RECIPE_LIST_QUERY_KEY, exact: false });
-      queryClient.invalidateQueries({ queryKey: RECIPE_DETAIL_QUERY_KEY(recipe.id) });
+      queryClient.invalidateQueries({ queryKey: RECIPE_QUERY_KEY.LIST(), exact: false });
+      queryClient.invalidateQueries({ queryKey: RECIPE_QUERY_KEY.BOOKMARK(recipe.id) });
     },
   });
 
   const { mutate: cancelBookMarkRecipe } = useCancelBookmarkRecipe({
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: RECIPE_LIST_QUERY_KEY, exact: false });
-      queryClient.invalidateQueries({ queryKey: RECIPE_DETAIL_QUERY_KEY(recipe.id) });
+      queryClient.invalidateQueries({ queryKey: RECIPE_QUERY_KEY.LIST(), exact: false });
+      queryClient.invalidateQueries({ queryKey: RECIPE_QUERY_KEY.BOOKMARK(recipe.id) });
     },
   });
 
@@ -52,7 +52,7 @@ const RecipeItem = ({ recipe, ...props }: RecipeListProps) => {
   const { mutate: deleteRecipe } = useDeleteRecipe({
     onSuccess: () => {
       router.push('/recipe');
-      queryClient.invalidateQueries({ queryKey: RECIPE_LIST_QUERY_KEY });
+      queryClient.invalidateQueries({ queryKey: RECIPE_QUERY_KEY.LIST() });
       showToast({ message: '레시피 삭제 완료!', type: 'success' });
     },
   });

--- a/src/app/(services)/recipe/write/forms.tsx
+++ b/src/app/(services)/recipe/write/forms.tsx
@@ -8,7 +8,7 @@ import Button from '@/components/atoms/button/Button';
 import Tab from '@/components/atoms/tab/Tab';
 import { useTabsContext } from '@/components/atoms/tab/Tab.context';
 import { COOK_TIME_OPTIONS, PRICE_OPTIONS } from '@/constants/options.constants';
-import { RECIPE_LIST_QUERY_KEY } from '@/constants/query-key.constants';
+import { RECIPE_QUERY_KEY } from '@/constants/query-key.constants';
 import { useAddRecipe } from '@/hooks/queries/recipe.hooks';
 import { zodAddRecipeForm } from '@/lib/zod/zodValidation';
 import { showToast } from '@/utils/functions';
@@ -26,7 +26,7 @@ const Forms = () => {
   const { mutate: addRecipe } = useAddRecipe({
     onSuccess: () => {
       router.push('/recipe');
-      queryClient.invalidateQueries({ queryKey: RECIPE_LIST_QUERY_KEY });
+      queryClient.invalidateQueries({ queryKey: RECIPE_QUERY_KEY.LIST() });
       showToast({ message: '레시피 등록 완료!', type: 'success' });
     },
   });

--- a/src/app/(services)/search/user/page.tsx
+++ b/src/app/(services)/search/user/page.tsx
@@ -10,7 +10,7 @@ import ProfileImage from '@/components/atoms/profile-image/ProfileImage';
 import { Text } from '@/components/atoms/text/Text';
 import InfiniteScroll from '@/components/organisms/infinite-scroll/InfiniteScroll';
 import { useGetUserInfo } from '@/hooks/queries/auth.hooks';
-import { useFollowUser, useGetUserList, useUnfollowUser } from '@/hooks/queries/users.hooks';
+import { useFollowUser, useSearchUserList, useUnfollowUser } from '@/hooks/queries/users.hooks';
 import { useLoginStore } from '@/lib/zustand/userStore';
 import { IUser } from '@/types/api';
 
@@ -26,7 +26,7 @@ const SearchUserPage = () => {
     fetchNextPage,
     hasNextPage,
     isFetching,
-  } = useGetUserList(keyword, isLoggedIn);
+  } = useSearchUserList(keyword, isLoggedIn);
 
   const { mutate: followUser } = useFollowUser();
   const { mutate: unfollowUser } = useUnfollowUser();

--- a/src/components/atoms/button/RecipeBookmarkButton.tsx
+++ b/src/components/atoms/button/RecipeBookmarkButton.tsx
@@ -1,7 +1,7 @@
 import { useQueryClient } from '@tanstack/react-query';
 
 import Bookmark from '@/components/molecules/bookmark/Bookmark';
-import { RECIPE_DETAIL_QUERY_KEY, RECIPE_LIST_QUERY_KEY } from '@/constants/query-key.constants';
+import { RECIPE_QUERY_KEY } from '@/constants/query-key.constants';
 import {
   useAddBookmarkRecipe,
   useCancelBookmarkRecipe,
@@ -19,15 +19,15 @@ const RecipeBookmarkButton = ({ recipeId }: RecipeBookmarkButtonProps) => {
 
   const { mutate: addBookmarkRecipe } = useAddBookmarkRecipe({
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: RECIPE_LIST_QUERY_KEY, exact: false });
-      queryClient.invalidateQueries({ queryKey: RECIPE_DETAIL_QUERY_KEY(recipeId) });
+      queryClient.invalidateQueries({ queryKey: RECIPE_QUERY_KEY.LIST() });
+      queryClient.invalidateQueries({ queryKey: RECIPE_QUERY_KEY.BOOKMARK(recipeId) });
     },
   });
 
   const { mutate: cancelBookMarkRecipe } = useCancelBookmarkRecipe({
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: RECIPE_LIST_QUERY_KEY, exact: false });
-      queryClient.invalidateQueries({ queryKey: RECIPE_DETAIL_QUERY_KEY(recipeId) });
+      queryClient.invalidateQueries({ queryKey: RECIPE_QUERY_KEY.LIST() });
+      queryClient.invalidateQueries({ queryKey: RECIPE_QUERY_KEY.BOOKMARK(recipeId) });
     },
   });
 

--- a/src/components/atoms/button/RecipeLikeButton.tsx
+++ b/src/components/atoms/button/RecipeLikeButton.tsx
@@ -1,6 +1,6 @@
 import { useQueryClient } from '@tanstack/react-query';
 
-import { MY_LIKE_LIST_QUERY_KEY, RECIPE_DETAIL_QUERY_KEY } from '@/constants/query-key.constants';
+import { RECIPE_QUERY_KEY } from '@/constants/query-key.constants';
 import {
   useAddLikeRecipe,
   useCancelLikeRecipe,
@@ -21,15 +21,15 @@ const RecipeLikeButton = ({ recipeId, likeCount }: RecipeLikeButtonProps) => {
 
   const { mutate: addLikeRecipe } = useAddLikeRecipe({
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: RECIPE_DETAIL_QUERY_KEY(recipeId) });
-      queryClient.invalidateQueries({ queryKey: MY_LIKE_LIST_QUERY_KEY });
+      queryClient.invalidateQueries({ queryKey: RECIPE_QUERY_KEY.DETAIL(recipeId) });
+      queryClient.invalidateQueries({ queryKey: RECIPE_QUERY_KEY.MY_LIKE_LIST() });
     },
   });
 
   const { mutate: cancelLikeRecipe } = useCancelLikeRecipe({
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: RECIPE_DETAIL_QUERY_KEY(recipeId) });
-      queryClient.invalidateQueries({ queryKey: MY_LIKE_LIST_QUERY_KEY });
+      queryClient.invalidateQueries({ queryKey: RECIPE_QUERY_KEY.DETAIL(recipeId) });
+      queryClient.invalidateQueries({ queryKey: RECIPE_QUERY_KEY.MY_LIKE_LIST() });
     },
   });
 

--- a/src/components/molecules/chat/ChatInput.tsx
+++ b/src/components/molecules/chat/ChatInput.tsx
@@ -5,11 +5,7 @@ import { useQueryClient } from '@tanstack/react-query';
 
 import { BoxIcon } from '@/components/atoms/icon/BoxIcon';
 import { Text } from '@/components/atoms/text/Text';
-import {
-  FEED_COMMENT_LIST_QUERY_KEY,
-  FEED_COMMENT_REPLY_LIST_QUERY_KEY,
-  FEED_QUERY_KEY,
-} from '@/constants/query-key.constants';
+import { FEED_QUERY_KEY } from '@/constants/query-key.constants';
 import { useAddComment, useAddCommentReply } from '@/hooks/queries/feed.hooks';
 import { cn } from '@/utils/cn';
 
@@ -30,9 +26,8 @@ const ChatInput = ({ logId, isReply, setIsReply, commentId }: IChatInputProps) =
   const { mutate: addComment } = useAddComment({
     onSuccess: (res) => {
       if (res.status === 201) {
-        queryClient.invalidateQueries({ queryKey: [FEED_QUERY_KEY, logId] });
-        queryClient.invalidateQueries({ queryKey: [FEED_COMMENT_LIST_QUERY_KEY, logId] });
-        queryClient.refetchQueries({ queryKey: [FEED_COMMENT_LIST_QUERY_KEY, logId] });
+        queryClient.invalidateQueries({ queryKey: FEED_QUERY_KEY.DETAIL(logId) });
+        queryClient.invalidateQueries({ queryKey: FEED_QUERY_KEY.COMMENT_LIST(logId) });
 
         setChatValue('');
       }
@@ -42,11 +37,10 @@ const ChatInput = ({ logId, isReply, setIsReply, commentId }: IChatInputProps) =
   const { mutate: addCommentReply } = useAddCommentReply({
     onSuccess: (res) => {
       if (res.status === 201) {
-        queryClient.invalidateQueries({ queryKey: [FEED_QUERY_KEY, logId] });
-        queryClient.invalidateQueries({ queryKey: [FEED_COMMENT_LIST_QUERY_KEY, logId] });
-        queryClient.refetchQueries({ queryKey: [FEED_COMMENT_LIST_QUERY_KEY, logId] });
+        queryClient.invalidateQueries({ queryKey: FEED_QUERY_KEY.DETAIL(logId) });
+        queryClient.invalidateQueries({ queryKey: FEED_QUERY_KEY.COMMENT_LIST(logId) });
         queryClient.invalidateQueries({
-          queryKey: [FEED_COMMENT_REPLY_LIST_QUERY_KEY, logId, commentId],
+          queryKey: FEED_QUERY_KEY.COMMENT_REPLY_LIST(logId, commentId),
         });
 
         setChatValue('');
@@ -115,9 +109,9 @@ const ChatInput = ({ logId, isReply, setIsReply, commentId }: IChatInputProps) =
             if (chatValue.trim() === '') return;
 
             if (isReply) {
-              addCommentReply({ boardId: logId, commentId: commentId, content: chatValue });
+              addCommentReply({ logId, commentId: commentId, content: chatValue });
             } else {
-              addComment({ id: logId, content: chatValue });
+              addComment({ logId, content: chatValue });
             }
           }}
         />

--- a/src/components/organisms/navigation/Navigation.tsx
+++ b/src/components/organisms/navigation/Navigation.tsx
@@ -22,7 +22,7 @@ const Navigation = () => {
 
   return (
     <nav
-      className={`align-center border-t-1 fixed bottom-0 box-border flex h-[72px] max-h-[80px] w-full max-w-lg justify-between border-grey07 bg-white01 px-[20px]`}
+      className={`align-center border-t-1 fixed bottom-0 box-border flex h-[72px] w-full max-w-lg justify-between border-grey07 bg-white01 px-[20px]`}
       style={{ zIndex: Z_INDEX.NAVIGATION }}
     >
       {MENU_ARR.map((menu) => {

--- a/src/constants/query-key.constants.ts
+++ b/src/constants/query-key.constants.ts
@@ -4,100 +4,139 @@ import {
   IGetRecipeReviewsParams,
   IGetRecipeSearchParams,
   IGetSortedRecipeOption,
+  IRecipeFilterParams,
   IRecipeIngredientParams,
   IRecipeProcessBySequenceParams,
   IRecipeProcessListParams,
+  ISearchFoodParams,
 } from '@/types/api';
 
-export const RECIPE_LIST_QUERY_KEY = ['recipe-list'];
-export const RECIPE_LIST_OPTIONS_QUERY_KEY = (
-  params: IGetRecipeParams,
-  option: IGetSortedRecipeOption & { isMine: boolean },
-) => [...RECIPE_LIST_QUERY_KEY, { ...params, ...option }];
+export const RECIPE_QUERY_KEY = {
+  ALL: () => ['recipe'],
+  LIST: () => [...RECIPE_QUERY_KEY.ALL(), 'list'],
+  LIST_WITH_PARAMS: (
+    params: IGetRecipeParams,
+    option: IGetSortedRecipeOption & { isMine: boolean },
+  ) => [...RECIPE_QUERY_KEY.LIST(), { ...params, ...option }],
+  LIST_BY_USER_ID: (userId: number) => [...RECIPE_QUERY_KEY.LIST(), 'user', { userId }],
+  LIST_BY_FILTER: (filterCondition: Partial<IRecipeFilterParams> | null) => [
+    ...RECIPE_QUERY_KEY.LIST(),
+    'filter',
+    { filterCondition },
+  ],
+  LIST_BY_FOOD: (keywords: string[]) => [...RECIPE_QUERY_KEY.LIST(), 'food', { ...keywords }],
+  SEARCH_WITH_PARAMS: (params: IGetRecipeSearchParams) => [
+    ...RECIPE_QUERY_KEY.LIST(),
+    'search',
+    { ...params },
+  ],
+  DETAIL: (recipeId: number) => ['recipe', 'detail', { recipeId }],
+  // ingredient
+  INGREDIENT_LIST: (recipeId: number) => ['recipe', 'ingredient', 'list', { recipeId }],
+  INGREDIENT_LIST_WITH_PARAMS: ({ recipeId, ...params }: IRecipeIngredientParams) => [
+    ...RECIPE_QUERY_KEY.INGREDIENT_LIST(recipeId),
+    { ...params },
+  ],
+  // process
+  PROCESS_LIST: (recipeId: number) => ['recipe', 'process', 'list', { recipeId }],
+  PROCESS_LIST_WITH_PARAMS: ({ recipeId, ...params }: IRecipeProcessListParams) => [
+    ...RECIPE_QUERY_KEY.PROCESS_LIST(recipeId),
+    { ...params },
+  ],
+  PROCESS: (recipeId: number) => ['recipe', 'process', { recipeId }],
+  PROCESS_WITH_PARAMS: ({ recipeId, ...params }: IRecipeProcessBySequenceParams) => [
+    ...RECIPE_QUERY_KEY.PROCESS(recipeId),
+    { ...params },
+  ],
+  // liked recipes
+  LIKE: (recipeId: number) => ['recipe', 'like', { recipeId }],
+  MY_LIKE_LIST: () => [...RECIPE_QUERY_KEY.LIST(), 'like', 'my'],
+  MY_LIKE_LIST_WITH_PARAMS: (params: IGetRecipeParams, option: IGetSortedRecipeOption) => [
+    ...RECIPE_QUERY_KEY.MY_LIKE_LIST(),
+    { ...params, ...option },
+  ],
+  // bookmarked recipes
+  BOOKMARK: (recipeId: number) => ['recipe', 'bookmark', { recipeId }],
+  MY_BOOKMARK_LIST: () => [...RECIPE_QUERY_KEY.LIST(), 'bookmark', 'my'],
+  MY_BOOKMARK_LIST_WITH_PARAMS: (params: IGetRecipeParams, option: IGetSortedRecipeOption) => [
+    ...RECIPE_QUERY_KEY.MY_BOOKMARK_LIST(),
+    { ...params, ...option },
+  ],
+  // reviews
+  REVIEW_LIST: () => [...RECIPE_QUERY_KEY.LIST(), 'review'],
+  REVIEW_LIST_BY_RECIPE_ID: (recipeId: number) => [...RECIPE_QUERY_KEY.REVIEW_LIST(), { recipeId }],
+  REVIEW_LIST_WITH_PARAMS: ({ recipeId, ...params }: IGetRecipeReviewsParams) => [
+    ...RECIPE_QUERY_KEY.REVIEW_LIST_BY_RECIPE_ID(recipeId),
+    { ...params },
+  ],
+  MY_REVIEW_LIST: () => [...RECIPE_QUERY_KEY.REVIEW_LIST(), 'my'],
+  REVIEW_DETAIL: ({ recipeId, reviewId }: IGetRecipeReviewDetailParams) => [
+    'recipe',
+    'review',
+    'detail',
+    recipeId,
+    reviewId,
+  ],
+  // memo
+  MEMO: (recipeId: number) => ['recipe', 'memo', { recipeId }],
+};
 
-export const RECIPE_DETAIL_QUERY_KEY = (recipeId: number) => ['recipe-detail', { recipeId }];
-export const RECIPE_INGREDIENT_LIST_QUERY_KEY_WITH_PARAMS = ({
-  recipeId,
-  ...params
-}: IRecipeIngredientParams) => [RECIPE_INGREDIENT_QUERY_KEY, recipeId, { ...params }];
-export const RECIPE_PROCESS_LIST_QUERY_KEY_WITH_PARAMS = (params: IRecipeProcessListParams) => [
-  'recipe-process',
-  { ...params },
-];
-export const RECIPE_PROCESS_QUERY_KEY_WITH_PARAMS = ({
-  recipeId,
-  ...params
-}: IRecipeProcessBySequenceParams) => ['recipe-process', recipeId, { ...params }];
-export const RECIPE_LIKE_QUERY_KEY = (recipeId: number) => [
-  ...RECIPE_DETAIL_QUERY_KEY(recipeId),
-  'like',
-];
-export const RECIPE_BOOKMARK_QUERY_KEY = (recipeId: number) => [
-  ...RECIPE_DETAIL_QUERY_KEY(recipeId),
-  'bookmark',
-];
-export const RECIPE_REVIEW_LIST_QUERY_KEY = (recipeId: IGetRecipeReviewsParams['recipeId']) => [
-  'recipe-review',
-  recipeId,
-];
-export const RECIPE_REVIEW_LIST_QUERY_KEY_WITH_PARAMS = ({
-  recipeId,
-  ...params
-}: IGetRecipeReviewsParams) => ['recipe-review', recipeId, { ...params }];
-export const RECIPE_MEMO_QUERY_KEY = (recipeId: number) => ['recipe-memo', recipeId];
-export const RECIPE_REVIEW_DETAIL_QUERY_KEY = (params: IGetRecipeReviewDetailParams) => [
-  'recipe-review-detail',
-  params,
-];
-export const RECIPE_SEARCH_QUERY_KEY_WITH_PARAMS = ({ ...params }: IGetRecipeSearchParams) => [
-  'recipe-search',
-  { ...params },
-];
+export const FEED_QUERY_KEY = {
+  ALL: () => ['feed'],
+  LIST: () => [...FEED_QUERY_KEY.ALL(), 'list'],
+  LIST_BY_USER_ID: (userId: number) => [...FEED_QUERY_KEY.LIST(), 'user', { userId }],
+  DETAIL: (logId: number) => [...FEED_QUERY_KEY.ALL(), 'detail', { logId }],
+  // comment
+  COMMENT_LIST: (logId: number) => [...FEED_QUERY_KEY.ALL(), 'comment', 'list', { logId }],
+  COMMENT_REPLY_LIST: (logId: number, commentId: number) => [
+    ...FEED_QUERY_KEY.ALL(),
+    'comment',
+    'reply',
+    'list',
+    { logId },
+    { commentId },
+  ],
+};
 
-export const RECIPE_INGREDIENT_QUERY_KEY = 'recipe-ingredient';
-export const FOOD_LIST_QUERY_KEY = 'food-list';
-export const USER_INFO_QUERY_KEY = 'user-info';
-export const FEED_LIST_QUERY_KEY = 'feed-list';
-export const FEED_QUERY_KEY = 'feed';
-export const FEED_COMMENT_LIST_QUERY_KEY = 'feed-comment-list';
-export const FEED_COMMENT_REPLY_LIST_QUERY_KEY = 'feed-comment-reply-list';
-export const FOLLOWING_COUNT_QUERY_KEY = 'following-count';
-export const FOLLOWER_COUNT_QUERY_KEY = 'follower-count';
-export const PROFILE_INFO_QUERY_KEY = 'profile-info';
-export const FOLLOWER_LIST_QUERY_KEY = 'follower-list';
-export const FOLLOWING_LIST_QUERY_KEY = 'following-list';
-export const RECIPE_LIST_BY_USER_ID_QUERY_KEY = 'recipe-list-by-user-id';
-export const FEED_LIST_BY_USER_ID_QUERY_KEY = 'feed-list-by-user-id';
-export const USER_LIST_QUERY_KEY = 'user-list';
-export const RECIPE_LIST_BY_FILTER_QUERY_KEY = 'recipe-list-by-filter';
-export const RECIPE_LIST_BY_FOOD_QUERY_KEY = 'recipe-list-by-food';
-export const BOOKMARK_LIST_QUERY_KEY = 'bookmark-list';
-export const MY_CHAT_ROOMS_QUERY_KEY = 'my-chat-rooms';
-export const CHATS_QUERY_KEY = 'chats';
+export const CHAT_QUERY_KEY = {
+  ALL: () => ['chat'],
+  // chat-room
+  MY_CHAT_ROOM_LIST: () => [...CHAT_QUERY_KEY.ALL(), 'list', 'room', 'my'],
+  // message
+  MESSAGE_LIST: (roomId: string) => [...CHAT_QUERY_KEY.ALL(), 'list', 'message', { roomId }],
+};
 
-// my
-export const MY_LIKE_LIST_QUERY_KEY = ['my-like-list'];
+export const USER_QUERY_KEY = {
+  ALL: () => ['user'],
+  LIST: () => [...USER_QUERY_KEY.ALL(), 'list'],
+  SEARCH: (keyword: string) => [...USER_QUERY_KEY.LIST(), 'search', { keyword }],
+  INFO: () => [...USER_QUERY_KEY.ALL(), 'info'],
+  PROFILE_INFO: (userId: number) => [...USER_QUERY_KEY.ALL(), 'profile', 'info', { userId }],
+  // follower
+  FOLLOWER: (userId: number) => [...USER_QUERY_KEY.ALL(), 'follower', { userId }],
+  FOLLOWER_LIST: (userId: number) => [...USER_QUERY_KEY.FOLLOWER(userId), 'list'],
+  FOLLOWER_COUNT: (userId: number) => [...USER_QUERY_KEY.FOLLOWER(userId), 'count'],
+  // following
+  FOLLOWING: (userId: number) => [...USER_QUERY_KEY.ALL(), 'following', { userId }],
+  FOLLOWING_LIST: (userId: number) => [...USER_QUERY_KEY.FOLLOWING(userId), 'list'],
+  FOLLOWING_COUNT: (userId: number) => [...USER_QUERY_KEY.FOLLOWING(userId), 'count'],
+  // shopping
+  SHOPPING_LIST: () => [...USER_QUERY_KEY.ALL(), 'shopping', 'list'],
+  // license
+  LiCENSE: () => [...USER_QUERY_KEY.ALL(), 'license'],
+  LICENSE_COUNT: () => [...USER_QUERY_KEY.LiCENSE(), 'count'],
+  LICENSE_LIST: (licenseType: string) => [...USER_QUERY_KEY.LiCENSE(), 'list', { licenseType }],
+  // point
+  POINT: () => [...USER_QUERY_KEY.ALL(), 'point'],
+  POINT_HISTORY: (type: string) => [...USER_QUERY_KEY.ALL(), 'point', 'history', { type }],
+};
 
-export const MY_LIKE_LIST_OPTIONS_QUERY_KEY = (
-  params: IGetRecipeParams,
-  option: IGetSortedRecipeOption,
-) => [...MY_LIKE_LIST_QUERY_KEY, { ...params, ...option }];
-
-export const MY_BOOKMARK_LIST_QUERY_KEY = ['my-bookmark-list'];
-
-export const MY_BOOKMARK_LIST_OPTIONS_QUERY_KEY = (
-  params: IGetRecipeParams,
-  option: IGetSortedRecipeOption,
-) => [...MY_BOOKMARK_LIST_QUERY_KEY, { ...params, ...option }];
-
-export const SHOPPING_LIST_QUERY_KEY = 'shopping-list';
-
-// license
-export const LICENSE_COUNT_QUERY_KEY = 'license-count';
-export const LICENSE_LIST_QUERY_KEY = 'license-list';
-
-// recipe review
-export const MY_RECIPE_REVIEW_LIST_QUERY_KEY = 'my-recipe-review-list';
-
-// point history
-export const POINT_HISTORY_QUERY_KEY = 'point-history';
+export const FOOD_QUERY_KEY = {
+  ALL: () => ['food'],
+  LIST: () => [...FOOD_QUERY_KEY.ALL(), 'list'],
+  SEARCH_WITH_PARAMS: (params: ISearchFoodParams) => [
+    ...FOOD_QUERY_KEY.LIST(),
+    'search',
+    { ...params },
+  ],
+};

--- a/src/hooks/queries/auth.hooks.ts
+++ b/src/hooks/queries/auth.hooks.ts
@@ -17,7 +17,7 @@ import {
   socialLink,
   updateUserInfo,
 } from '@/apis/auth.api';
-import { USER_INFO_QUERY_KEY } from '@/constants/query-key.constants';
+import { USER_QUERY_KEY } from '@/constants/query-key.constants';
 import { useLoginStore } from '@/lib/zustand/userStore';
 import { IMutationOptions, TChangePasswordFormData, TFindAccountFormValues } from '@/types/api';
 import { showErrorToast, showToast } from '@/utils/functions';
@@ -87,10 +87,8 @@ export function useLogout() {
     onSuccess: (res) => {
       if (res.status === 200) {
         setIsLoggedIn(false);
-
+        queryClient.removeQueries({ queryKey: USER_QUERY_KEY.INFO() });
         router.push('/login');
-
-        queryClient.removeQueries({ queryKey: [USER_INFO_QUERY_KEY] });
       }
     },
   });
@@ -128,7 +126,7 @@ export function useGetUserInfo() {
   const { isLoggedIn } = useLoginStore();
 
   return useQuery({
-    queryKey: [USER_INFO_QUERY_KEY],
+    queryKey: USER_QUERY_KEY.INFO(),
     queryFn: () => getUserInfo(),
     enabled: isLoggedIn,
     select: (res) => res.data,
@@ -161,7 +159,7 @@ export function useUnregister() {
         router.push('/login');
         showToast({ message: '회원 탈퇴가 완료되었습니다.', type: 'success' });
 
-        queryClient.removeQueries({ queryKey: [USER_INFO_QUERY_KEY] });
+        queryClient.removeQueries({ queryKey: USER_QUERY_KEY.INFO() });
       }
     },
   });

--- a/src/hooks/queries/chat.hooks.ts
+++ b/src/hooks/queries/chat.hooks.ts
@@ -1,11 +1,11 @@
 import { queryOptions, useQuery } from '@tanstack/react-query';
 
 import { getChatRoomMessages, getMyChatRooms } from '@/apis/chat.api';
-import { CHATS_QUERY_KEY, MY_CHAT_ROOMS_QUERY_KEY } from '@/constants/query-key.constants';
+import { CHAT_QUERY_KEY } from '@/constants/query-key.constants';
 
 export const getMyChatRoomsQueryOptions = () =>
   queryOptions({
-    queryKey: [MY_CHAT_ROOMS_QUERY_KEY],
+    queryKey: CHAT_QUERY_KEY.MY_CHAT_ROOM_LIST(),
     queryFn: () => getMyChatRooms(),
     select: (response) => response.data,
     staleTime: 0,
@@ -13,7 +13,7 @@ export const getMyChatRoomsQueryOptions = () =>
 
 export const getChatsQueryOptions = (roomId: string) =>
   queryOptions({
-    queryKey: [CHATS_QUERY_KEY, roomId],
+    queryKey: CHAT_QUERY_KEY.MESSAGE_LIST(roomId),
     queryFn: () => getChatRoomMessages(roomId),
     select: (response) => response.data,
     staleTime: 0,

--- a/src/hooks/queries/feed.hooks.ts
+++ b/src/hooks/queries/feed.hooks.ts
@@ -13,17 +13,12 @@ import {
   getLogList,
   removeLogLike,
 } from '@/apis/feed.api';
-import {
-  FEED_COMMENT_LIST_QUERY_KEY,
-  FEED_COMMENT_REPLY_LIST_QUERY_KEY,
-  FEED_LIST_QUERY_KEY,
-  FEED_QUERY_KEY,
-} from '@/constants/query-key.constants';
+import { FEED_QUERY_KEY } from '@/constants/query-key.constants';
 import { IMutationOptions } from '@/types/api';
 
 export function useGetLogList() {
   return useInfiniteQuery({
-    queryKey: [FEED_LIST_QUERY_KEY],
+    queryKey: FEED_QUERY_KEY.LIST(),
     queryFn: async ({ pageParam = 0 }) => await getLogList(pageParam),
     initialPageParam: 0,
     getNextPageParam: (lastPage, _, pageParam) =>
@@ -41,17 +36,18 @@ export function useAddLog(options?: IMutationOptions) {
 
 export function useEditLog(options?: IMutationOptions) {
   return useMutation({
-    mutationFn: ({ id, formData }: { id: number; formData: FormData }) => editLog(id, formData),
+    mutationFn: ({ logId, formData }: { logId: number; formData: FormData }) =>
+      editLog(logId, formData),
     onSuccess: options?.onSuccess,
     onError: options?.onError,
   });
 }
 
-export function useGetLog(id: number) {
+export function useGetLog(logId: number) {
   return useQuery({
-    queryKey: [FEED_QUERY_KEY, id],
-    queryFn: () => getLog(id),
-    enabled: !!id && id !== -1,
+    queryKey: FEED_QUERY_KEY.DETAIL(logId),
+    queryFn: () => getLog(logId),
+    enabled: !!logId && logId !== -1,
     select: (res) => res.data,
   });
 }
@@ -80,10 +76,10 @@ export function useRemoveLike(options?: IMutationOptions) {
   });
 }
 
-export function useGetCommentList(id: number) {
+export function useGetCommentList(logId: number) {
   return useInfiniteQuery({
-    queryKey: [FEED_COMMENT_LIST_QUERY_KEY, id],
-    queryFn: async ({ pageParam = 0 }) => await getLogCommentList(id, pageParam),
+    queryKey: FEED_QUERY_KEY.COMMENT_LIST(logId),
+    queryFn: async ({ pageParam = 0 }) => await getLogCommentList(logId, pageParam),
     initialPageParam: 0,
     getNextPageParam: (lastPage, _, pageParam) =>
       lastPage.data.hasNext ? pageParam + 1 : undefined,
@@ -95,7 +91,8 @@ export function useGetCommentList(id: number) {
 
 export function useAddComment(options?: IMutationOptions) {
   return useMutation({
-    mutationFn: ({ id, content }: { id: number; content: string }) => addLogComment(id, content),
+    mutationFn: ({ logId, content }: { logId: number; content: string }) =>
+      addLogComment(logId, content),
     onSuccess: options?.onSuccess,
     onError: options?.onError,
   });
@@ -104,28 +101,27 @@ export function useAddComment(options?: IMutationOptions) {
 export function useAddCommentReply(options?: IMutationOptions) {
   return useMutation({
     mutationFn: ({
-      boardId,
+      logId,
       commentId,
       content,
     }: {
-      boardId: number;
+      logId: number;
       commentId: number;
       content: string;
-    }) => addLogCommentReply(boardId, commentId, content),
+    }) => addLogCommentReply(logId, commentId, content),
     onSuccess: options?.onSuccess,
     onError: options?.onError,
   });
 }
 
-export function useGetCommentReplyList(boardId: number, commentId: number, enabled: boolean) {
+export function useGetCommentReplyList(logId: number, commentId: number, enabled: boolean) {
   return useInfiniteQuery({
-    queryKey: [FEED_COMMENT_REPLY_LIST_QUERY_KEY, boardId, commentId],
-    queryFn: async ({ pageParam = 0 }) =>
-      await getLogCommentReplyList(boardId, commentId, pageParam),
+    queryKey: FEED_QUERY_KEY.COMMENT_REPLY_LIST(logId, commentId),
+    queryFn: async ({ pageParam = 0 }) => await getLogCommentReplyList(logId, commentId, pageParam),
     initialPageParam: 0,
     getNextPageParam: (lastPage, _, pageParam) =>
       lastPage.data.hasNext ? pageParam + 1 : undefined,
-    enabled: enabled && !!boardId && !!commentId,
+    enabled: enabled && !!logId && !!commentId,
     refetchOnMount: true,
     refetchOnWindowFocus: true,
     staleTime: 0,

--- a/src/hooks/queries/food.hooks.ts
+++ b/src/hooks/queries/food.hooks.ts
@@ -1,12 +1,12 @@
 import { useInfiniteQuery } from '@tanstack/react-query';
 
 import { searchFood } from '@/apis/food.api';
-import { FOOD_LIST_QUERY_KEY } from '@/constants/query-key.constants';
+import { FOOD_QUERY_KEY } from '@/constants/query-key.constants';
 import { ISearchFoodParams } from '@/types/api';
 
 export function useSearchFood(params: ISearchFoodParams) {
   return useInfiniteQuery({
-    queryKey: [FOOD_LIST_QUERY_KEY, { search: params.search }],
+    queryKey: FOOD_QUERY_KEY.SEARCH_WITH_PARAMS(params),
     queryFn: async ({ pageParam }) => await searchFood({ ...params, page: pageParam }),
     initialPageParam: params.page,
     getNextPageParam: (lastPage, _, pageParam) =>

--- a/src/hooks/queries/my.hooks.ts
+++ b/src/hooks/queries/my.hooks.ts
@@ -10,14 +10,7 @@ import {
   requestExpertVerification,
   uploadLicense,
 } from '@/apis/my.api';
-import {
-  LICENSE_COUNT_QUERY_KEY,
-  LICENSE_LIST_QUERY_KEY,
-  MY_BOOKMARK_LIST_OPTIONS_QUERY_KEY,
-  MY_LIKE_LIST_OPTIONS_QUERY_KEY,
-  MY_RECIPE_REVIEW_LIST_QUERY_KEY,
-  POINT_HISTORY_QUERY_KEY,
-} from '@/constants/query-key.constants';
+import { RECIPE_QUERY_KEY, USER_QUERY_KEY } from '@/constants/query-key.constants';
 import { IGetRecipeParams, IGetSortedRecipeOption, IMutationOptions } from '@/types/api';
 import { showToast } from '@/utils/functions';
 
@@ -25,7 +18,7 @@ export const useGetMyLikesList = (params: IGetRecipeParams, option: IGetSortedRe
   const { ...sortOptions } = option;
 
   return useInfiniteQuery({
-    queryKey: MY_LIKE_LIST_OPTIONS_QUERY_KEY(params, option),
+    queryKey: RECIPE_QUERY_KEY.MY_LIKE_LIST_WITH_PARAMS(params, option),
     queryFn: async ({ pageParam }) =>
       await getMyLikeList({ ...params, page: pageParam }, sortOptions),
     initialPageParam: params.page,
@@ -39,7 +32,7 @@ export const useGetMyBookmarkList = (params: IGetRecipeParams, option: IGetSorte
   const { ...sortOptions } = option;
 
   return useInfiniteQuery({
-    queryKey: MY_BOOKMARK_LIST_OPTIONS_QUERY_KEY(params, option),
+    queryKey: RECIPE_QUERY_KEY.MY_BOOKMARK_LIST_WITH_PARAMS(params, option),
     queryFn: async ({ pageParam }) =>
       await getMyBookmarkList({ ...params, page: pageParam }, sortOptions),
     initialPageParam: params.page,
@@ -70,7 +63,7 @@ export const useUploadLicense = (options?: IMutationOptions) => {
 
 export const useGetLicenseList = (licenseType: string) => {
   return useInfiniteQuery({
-    queryKey: [LICENSE_LIST_QUERY_KEY, licenseType],
+    queryKey: USER_QUERY_KEY.LICENSE_LIST(licenseType),
     queryFn: async ({ pageParam }) => await getLicenseList(pageParam, licenseType),
     initialPageParam: 0,
     getNextPageParam: (lastPage, _, pageParam) =>
@@ -82,7 +75,7 @@ export const useGetLicenseList = (licenseType: string) => {
 
 export const useGetLicenseCount = () => {
   return useQuery({
-    queryKey: [LICENSE_COUNT_QUERY_KEY],
+    queryKey: USER_QUERY_KEY.LICENSE_COUNT(),
     queryFn: async () => await getLicenseCount(),
     select: (response) => response.data,
   });
@@ -90,7 +83,7 @@ export const useGetLicenseCount = () => {
 
 export const useGetMyRecipeReview = ({ userId }: { userId: number | undefined }) => {
   return useInfiniteQuery({
-    queryKey: [MY_RECIPE_REVIEW_LIST_QUERY_KEY],
+    queryKey: RECIPE_QUERY_KEY.MY_REVIEW_LIST(),
     queryFn: async ({ pageParam = 0 }) => await getMyRecipeReview(userId, pageParam),
 
     initialPageParam: 0,
@@ -103,7 +96,7 @@ export const useGetMyRecipeReview = ({ userId }: { userId: number | undefined })
 
 export const useGetPointHistory = (type: string) => {
   return useInfiniteQuery({
-    queryKey: [POINT_HISTORY_QUERY_KEY, type],
+    queryKey: USER_QUERY_KEY.POINT_HISTORY(type),
     queryFn: async ({ pageParam }) => await getPointHistory(pageParam, type),
     initialPageParam: 0,
     getNextPageParam: (lastPage, _, pageParam) =>

--- a/src/hooks/queries/recipe.hooks.ts
+++ b/src/hooks/queries/recipe.hooks.ts
@@ -30,21 +30,7 @@ import {
   updateRecipe,
   updateRecipeMemo,
 } from '@/apis/recipe.api';
-import {
-  RECIPE_BOOKMARK_QUERY_KEY,
-  RECIPE_DETAIL_QUERY_KEY,
-  RECIPE_INGREDIENT_LIST_QUERY_KEY_WITH_PARAMS,
-  RECIPE_LIKE_QUERY_KEY,
-  RECIPE_LIST_BY_FILTER_QUERY_KEY,
-  RECIPE_LIST_BY_FOOD_QUERY_KEY,
-  RECIPE_LIST_OPTIONS_QUERY_KEY,
-  RECIPE_MEMO_QUERY_KEY,
-  RECIPE_PROCESS_LIST_QUERY_KEY_WITH_PARAMS,
-  RECIPE_PROCESS_QUERY_KEY_WITH_PARAMS,
-  RECIPE_REVIEW_DETAIL_QUERY_KEY,
-  RECIPE_REVIEW_LIST_QUERY_KEY_WITH_PARAMS,
-  RECIPE_SEARCH_QUERY_KEY_WITH_PARAMS,
-} from '@/constants/query-key.constants';
+import { RECIPE_QUERY_KEY } from '@/constants/query-key.constants';
 import {
   IAddBookmarkRecipeParams,
   IAddLikeRecipeParams,
@@ -101,7 +87,7 @@ export const useGetSortedRecipe = (
 ) => {
   const { isMine, ...sortOptions } = option;
   return useInfiniteQuery({
-    queryKey: RECIPE_LIST_OPTIONS_QUERY_KEY(params, option),
+    queryKey: RECIPE_QUERY_KEY.LIST_WITH_PARAMS(params, option),
     queryFn: async ({ pageParam }) =>
       isMine
         ? await getMySortedRecipeList({ ...params, page: pageParam }, sortOptions)
@@ -116,7 +102,7 @@ export const useGetSortedRecipe = (
 export const useGetRecipeDetail = (params: IRecipeDetailParams, options?: { enabled: boolean }) => {
   const { recipeId } = params;
   return useQuery({
-    queryKey: RECIPE_DETAIL_QUERY_KEY(recipeId),
+    queryKey: RECIPE_QUERY_KEY.DETAIL(recipeId),
     queryFn: () => getRecipeDetail(params),
     ...options,
     enabled: !!params.recipeId,
@@ -129,7 +115,7 @@ export const useGetRecipeIngredientList = (
   options?: { enabled: boolean },
 ) => {
   return useInfiniteQuery({
-    queryKey: RECIPE_INGREDIENT_LIST_QUERY_KEY_WITH_PARAMS(params),
+    queryKey: RECIPE_QUERY_KEY.INGREDIENT_LIST_WITH_PARAMS(params),
     queryFn: () => getRecipeIngredientList(params),
     initialPageParam: params.page,
     getNextPageParam: (lastPage, _, pageParam) =>
@@ -149,7 +135,7 @@ export const useGetRecipeIngredientList = (
 // 레시피 조리 과정
 export const useGetRecipeProcesses = (params: IRecipeProcessListParams) => {
   return useInfiniteQuery({
-    queryKey: RECIPE_PROCESS_LIST_QUERY_KEY_WITH_PARAMS(params),
+    queryKey: RECIPE_QUERY_KEY.PROCESS_LIST_WITH_PARAMS(params),
     queryFn: () => getRecipeProcessList(params),
     initialPageParam: params.page,
     getNextPageParam: (lastPage, _, pageParam) =>
@@ -164,7 +150,7 @@ export const useGetRecipeProcesses = (params: IRecipeProcessListParams) => {
 
 export const useGetRecipeProcessBySequence = (params: IRecipeProcessBySequenceParams) => {
   return useQuery({
-    queryKey: RECIPE_PROCESS_QUERY_KEY_WITH_PARAMS(params),
+    queryKey: RECIPE_QUERY_KEY.PROCESS_WITH_PARAMS(params),
     queryFn: () => getRecipeProcessBySequence(params),
   });
 };
@@ -173,7 +159,7 @@ export const useGetRecipeProcessBySequence = (params: IRecipeProcessBySequencePa
 export function useGetRecipeLike(params: IGetRecipeLikeParams) {
   const { recipeId } = params;
   return useQuery({
-    queryKey: RECIPE_LIKE_QUERY_KEY(recipeId),
+    queryKey: RECIPE_QUERY_KEY.LIKE(recipeId),
     queryFn: () => getRecipeLike(params),
   });
 }
@@ -196,7 +182,7 @@ export function useCancelLikeRecipe(options?: IMutationOptions) {
 export function useGetRecipeBookmark(params: IGetRecipeLikeParams) {
   const { recipeId } = params;
   return useQuery({
-    queryKey: RECIPE_BOOKMARK_QUERY_KEY(recipeId),
+    queryKey: RECIPE_QUERY_KEY.BOOKMARK(recipeId),
     queryFn: () => getRecipeBookmark(params),
   });
 }
@@ -218,7 +204,7 @@ export function useCancelBookmarkRecipe(options?: IMutationOptions) {
 // 레시피 필터
 export const useGetRecipeByFilter = (filterCondition: Partial<IRecipeFilterParams> | null) => {
   return useInfiniteQuery({
-    queryKey: [RECIPE_LIST_BY_FILTER_QUERY_KEY, filterCondition],
+    queryKey: RECIPE_QUERY_KEY.LIST_BY_FILTER(filterCondition),
     queryFn: ({ pageParam = 0 }) =>
       getRecipeByFilter({ condition: filterCondition, page: pageParam }),
     initialPageParam: 0,
@@ -233,7 +219,7 @@ export const useGetRecipeByFilter = (filterCondition: Partial<IRecipeFilterParam
 
 export const useGetRecipeByFood = (keywords: string[]) => {
   return useInfiniteQuery({
-    queryKey: [RECIPE_LIST_BY_FOOD_QUERY_KEY, keywords],
+    queryKey: RECIPE_QUERY_KEY.LIST_BY_FOOD(keywords),
     queryFn: ({ pageParam = 0 }) => getRecipeByFood({ keywords, page: pageParam }),
     initialPageParam: 0,
     getNextPageParam: (lastPage, _, pageParam) =>
@@ -255,7 +241,7 @@ export function usePayRecipe(options?: IMutationOptions) {
 // 레시피 리뷰
 export const useGetReviews = (params: IGetRecipeReviewsParams) => {
   return useInfiniteQuery({
-    queryKey: RECIPE_REVIEW_LIST_QUERY_KEY_WITH_PARAMS(params),
+    queryKey: RECIPE_QUERY_KEY.REVIEW_LIST_WITH_PARAMS(params),
     queryFn: ({ pageParam = 0 }) => getRecipeReviews({ ...params, page: pageParam }),
     initialPageParam: params.page,
     getNextPageParam: (lastPage, _, pageParam) =>
@@ -283,7 +269,7 @@ export function useAddReviewReply(options?: IMutationOptions) {
 
 export function useGetRecipeReviewDetail(params: IGetRecipeReviewDetailParams) {
   return useQuery({
-    queryKey: RECIPE_REVIEW_DETAIL_QUERY_KEY(params),
+    queryKey: RECIPE_QUERY_KEY.REVIEW_DETAIL(params),
     queryFn: () => getRecipeReviewDetail(params),
     select: (data) => data.data,
   });
@@ -313,14 +299,14 @@ export function useUpdateRecipeMemo(options?: IMutationOptions) {
 
 export function useGetRecipeMemo({ recipeId }: IGetRecipeMemoParams) {
   return useQuery({
-    queryKey: RECIPE_MEMO_QUERY_KEY(recipeId),
+    queryKey: RECIPE_QUERY_KEY.MEMO(recipeId),
     queryFn: () => getRecipeMemo({ recipeId }),
   });
 }
 
 export const useGetRecipeSearch = (params: IGetRecipeSearchParams) => {
   return useInfiniteQuery({
-    queryKey: RECIPE_SEARCH_QUERY_KEY_WITH_PARAMS(params),
+    queryKey: RECIPE_QUERY_KEY.SEARCH_WITH_PARAMS(params),
     queryFn: ({ pageParam = 0 }) => getRecipeSearch({ ...params, page: pageParam }),
     initialPageParam: params.page,
     getNextPageParam: (lastPage, _, pageParam) =>

--- a/src/hooks/queries/shopping.hooks.ts
+++ b/src/hooks/queries/shopping.hooks.ts
@@ -1,7 +1,7 @@
 import { useInfiniteQuery, useMutation } from '@tanstack/react-query';
 
 import { addShoppingList, getShoppingList, removeShoppingList } from '@/apis/shopping.api';
-import { SHOPPING_LIST_QUERY_KEY } from '@/constants/query-key.constants';
+import { USER_QUERY_KEY } from '@/constants/query-key.constants';
 import { AddShoppingListPayload, IMutationOptions, RemoveShoppingListParams } from '@/types/api';
 
 export function useAddShoppingList(options?: IMutationOptions) {
@@ -22,7 +22,7 @@ export function useRemoveShoppingList(options?: IMutationOptions) {
 
 export function useGetShoppingList() {
   return useInfiniteQuery({
-    queryKey: [SHOPPING_LIST_QUERY_KEY],
+    queryKey: USER_QUERY_KEY.SHOPPING_LIST(),
     queryFn: async ({ pageParam = 0 }) => await getShoppingList(pageParam),
     initialPageParam: 0,
     getNextPageParam: (lastPage, _, pageParam) =>

--- a/src/hooks/queries/users.hooks.ts
+++ b/src/hooks/queries/users.hooks.ts
@@ -12,38 +12,29 @@ import {
   getUserList,
   unfollowUser,
 } from '@/apis/users.api';
-import {
-  FEED_LIST_BY_USER_ID_QUERY_KEY,
-  FOLLOWER_COUNT_QUERY_KEY,
-  FOLLOWER_LIST_QUERY_KEY,
-  FOLLOWING_COUNT_QUERY_KEY,
-  FOLLOWING_LIST_QUERY_KEY,
-  PROFILE_INFO_QUERY_KEY,
-  RECIPE_LIST_BY_USER_ID_QUERY_KEY,
-  USER_LIST_QUERY_KEY,
-} from '@/constants/query-key.constants';
+import { FEED_QUERY_KEY, RECIPE_QUERY_KEY, USER_QUERY_KEY } from '@/constants/query-key.constants';
 import { showErrorToast } from '@/utils/functions';
 
-export const useGetFollowingCount = (id: number) => {
+export const useGetFollowingCount = (userId: number) => {
   return useQuery({
-    queryKey: [FOLLOWING_COUNT_QUERY_KEY, id],
-    queryFn: () => getFollowingCount(id),
+    queryKey: USER_QUERY_KEY.FOLLOWING_COUNT(userId),
+    queryFn: () => getFollowingCount(userId),
   });
 };
 
-export const useGetFollowerCount = (id: number) => {
+export const useGetFollowerCount = (userId: number) => {
   return useQuery({
-    queryKey: [FOLLOWER_COUNT_QUERY_KEY, id],
-    queryFn: () => getFollowerCount(id),
+    queryKey: USER_QUERY_KEY.FOLLOWER_COUNT(userId),
+    queryFn: () => getFollowerCount(userId),
   });
 };
 
-export const useGetProfileInfo = (id: number) => {
+export const useGetProfileInfo = (userId: number) => {
   return useQuery({
-    queryKey: [PROFILE_INFO_QUERY_KEY, id],
-    queryFn: () => getProfileInfo(id),
+    queryKey: USER_QUERY_KEY.PROFILE_INFO(userId),
+    queryFn: () => getProfileInfo(userId),
     select: (data) => data.data,
-    enabled: !!id,
+    enabled: !!userId,
   });
 };
 
@@ -54,11 +45,10 @@ export function useFollowUser() {
     mutationFn: ({ userId }: { userId: number; followedBy: number }) => followUser(userId),
     onSuccess: (res, { userId, followedBy }) => {
       if (res.status === 201 || res.status === 200) {
-        queryClient.invalidateQueries({ queryKey: [USER_LIST_QUERY_KEY] });
-        queryClient.invalidateQueries({ queryKey: [PROFILE_INFO_QUERY_KEY, Number(userId)] });
-        queryClient.invalidateQueries({ queryKey: [FOLLOWER_COUNT_QUERY_KEY, Number(userId)] });
-        queryClient.invalidateQueries({ queryKey: [FOLLOWER_LIST_QUERY_KEY, Number(userId)] });
-        queryClient.invalidateQueries({ queryKey: [FOLLOWING_LIST_QUERY_KEY, Number(followedBy)] });
+        queryClient.invalidateQueries({ queryKey: USER_QUERY_KEY.LIST() });
+        queryClient.invalidateQueries({ queryKey: USER_QUERY_KEY.PROFILE_INFO(userId) });
+        queryClient.invalidateQueries({ queryKey: USER_QUERY_KEY.FOLLOWER(userId) });
+        queryClient.invalidateQueries({ queryKey: USER_QUERY_KEY.FOLLOWING(followedBy) });
       }
     },
     onError: (err) => {
@@ -74,16 +64,10 @@ export function useUnfollowUser() {
     mutationFn: ({ userId }: { userId: number; unfollowedBy: number }) => unfollowUser(userId),
     onSuccess: (res, { userId, unfollowedBy }) => {
       if (res.status === 201 || res.status === 200) {
-        queryClient.invalidateQueries({ queryKey: [USER_LIST_QUERY_KEY] });
-        queryClient.invalidateQueries({ queryKey: [PROFILE_INFO_QUERY_KEY, Number(userId)] });
-        queryClient.invalidateQueries({ queryKey: [FOLLOWER_COUNT_QUERY_KEY, Number(userId)] });
-        queryClient.invalidateQueries({ queryKey: [FOLLOWER_LIST_QUERY_KEY, Number(userId)] });
-        queryClient.invalidateQueries({
-          queryKey: [FOLLOWING_COUNT_QUERY_KEY, Number(unfollowedBy)],
-        });
-        queryClient.invalidateQueries({
-          queryKey: [FOLLOWING_LIST_QUERY_KEY, Number(unfollowedBy)],
-        });
+        queryClient.invalidateQueries({ queryKey: USER_QUERY_KEY.LIST() });
+        queryClient.invalidateQueries({ queryKey: USER_QUERY_KEY.PROFILE_INFO(userId) });
+        queryClient.invalidateQueries({ queryKey: USER_QUERY_KEY.FOLLOWER(userId) });
+        queryClient.invalidateQueries({ queryKey: USER_QUERY_KEY.FOLLOWING(unfollowedBy) });
       }
     },
     onError: (err) => {
@@ -94,7 +78,7 @@ export function useUnfollowUser() {
 
 export function useGetFollowerList(id: number, isFollower: boolean) {
   return useInfiniteQuery({
-    queryKey: [FOLLOWER_LIST_QUERY_KEY, id],
+    queryKey: USER_QUERY_KEY.FOLLOWER_LIST(id),
     queryFn: async ({ pageParam = 0 }) => await getFollowerList(id, pageParam),
     enabled: isFollower,
     initialPageParam: 0,
@@ -106,7 +90,7 @@ export function useGetFollowerList(id: number, isFollower: boolean) {
 
 export function useGetFollowingList(id: number, isFollower: boolean) {
   return useInfiniteQuery({
-    queryKey: [FOLLOWING_LIST_QUERY_KEY, id],
+    queryKey: USER_QUERY_KEY.FOLLOWING_LIST(id),
     queryFn: async ({ pageParam = 0 }) => await getFollowingList(id, pageParam),
     initialPageParam: 0,
     enabled: !isFollower,
@@ -118,7 +102,7 @@ export function useGetFollowingList(id: number, isFollower: boolean) {
 
 export function useGetRecipeListByUserId(userId: number) {
   return useInfiniteQuery({
-    queryKey: [RECIPE_LIST_BY_USER_ID_QUERY_KEY, userId],
+    queryKey: RECIPE_QUERY_KEY.LIST_BY_USER_ID(userId),
     queryFn: async ({ pageParam = 0 }) => await getRecipeListByUserId(userId, pageParam),
     initialPageParam: 0,
     enabled: !!userId,
@@ -129,7 +113,7 @@ export function useGetRecipeListByUserId(userId: number) {
 
 export function useGetFeedListByUserId(userId: number) {
   return useInfiniteQuery({
-    queryKey: [FEED_LIST_BY_USER_ID_QUERY_KEY, userId],
+    queryKey: FEED_QUERY_KEY.LIST_BY_USER_ID(userId),
     queryFn: async ({ pageParam = 0 }) => await getFeedListByUserId(userId, pageParam),
     initialPageParam: 0,
     enabled: !!userId,
@@ -138,13 +122,13 @@ export function useGetFeedListByUserId(userId: number) {
   });
 }
 
-export function useGetUserList(nickname: string, isLoggedIn: boolean) {
+export function useSearchUserList(keyword: string, isLoggedIn: boolean) {
   return useInfiniteQuery({
-    queryKey: [USER_LIST_QUERY_KEY, nickname],
-    queryFn: async ({ pageParam = 0 }) => await getUserList(nickname, pageParam, isLoggedIn),
+    queryKey: USER_QUERY_KEY.SEARCH(keyword),
+    queryFn: async ({ pageParam = 0 }) => await getUserList(keyword, pageParam, isLoggedIn),
     initialPageParam: 0,
     getNextPageParam: (lastPage, _, pageParam) =>
       lastPage.data.hasNext ? pageParam + 1 : undefined,
-    enabled: !!nickname,
+    enabled: !!keyword,
   });
 }

--- a/src/hooks/useFeedDetailActions.ts
+++ b/src/hooks/useFeedDetailActions.ts
@@ -3,7 +3,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 
 import { DELETE_FEED_MODAL } from '@/constants/modal.constants';
-import { FEED_LIST_QUERY_KEY } from '@/constants/query-key.constants';
+import { FEED_QUERY_KEY } from '@/constants/query-key.constants';
 import { useDeleteLog } from '@/hooks/queries/feed.hooks';
 import { showToast } from '@/utils/functions';
 
@@ -24,7 +24,7 @@ export const useFeedDetailActions = () => {
         const modal = document.getElementById(DELETE_FEED_MODAL) as HTMLDialogElement;
         modal.close();
         showToast({ message: '일기를 삭제했습니다.', type: 'success' });
-        queryClient.invalidateQueries({ queryKey: [FEED_LIST_QUERY_KEY] });
+        queryClient.invalidateQueries({ queryKey: FEED_QUERY_KEY.LIST() });
         router.push('/feed');
       }
     },

--- a/src/hooks/useFeedItemActions.ts
+++ b/src/hooks/useFeedItemActions.ts
@@ -2,7 +2,7 @@ import { useCallback, useRef, useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 
 import { DELETE_FEED_MODAL } from '@/constants/modal.constants';
-import { FEED_LIST_QUERY_KEY } from '@/constants/query-key.constants';
+import { FEED_QUERY_KEY } from '@/constants/query-key.constants';
 import { useDeleteLog } from '@/hooks/queries/feed.hooks';
 import { showToast } from '@/utils/functions';
 
@@ -22,7 +22,7 @@ export const useFeedItemActions = (options?: UseFeedItemActionsOptions) => {
         const modal = document.getElementById(DELETE_FEED_MODAL) as HTMLDialogElement;
         modal.close();
         showToast({ message: '일기를 삭제했습니다.', type: 'success' });
-        queryClient.invalidateQueries({ queryKey: [FEED_LIST_QUERY_KEY] });
+        queryClient.invalidateQueries({ queryKey: FEED_QUERY_KEY.LIST() });
         options?.onDeleteSuccess?.();
       }
     },

--- a/src/services/feed.services.ts
+++ b/src/services/feed.services.ts
@@ -1,6 +1,6 @@
 import { QueryClient } from '@tanstack/react-query';
 
-import { FEED_LIST_QUERY_KEY, FEED_QUERY_KEY } from '@/constants/query-key.constants';
+import { FEED_QUERY_KEY } from '@/constants/query-key.constants';
 import { ILogResponse } from '@/types/api';
 
 interface IFeedListResponse {
@@ -18,7 +18,7 @@ export const ToggleLikeSuccess = (log: ILogResponse, queryClient: QueryClient) =
   const likeCountChange = newIsLike ? 1 : -1;
 
   // 피드 리스트 캐시 업데이트
-  queryClient.setQueryData<IFeedListResponse>([FEED_LIST_QUERY_KEY], (oldData) => {
+  queryClient.setQueryData<IFeedListResponse>(FEED_QUERY_KEY.LIST(), (oldData) => {
     if (!oldData) return oldData;
 
     return {
@@ -43,7 +43,7 @@ export const ToggleLikeSuccess = (log: ILogResponse, queryClient: QueryClient) =
 
   // 개별 게시글 캐시 업데이트
   queryClient.setQueryData(
-    [FEED_QUERY_KEY, Number(log.id)],
+    FEED_QUERY_KEY.DETAIL(log.id),
     (oldData: ILogResponse | { data: ILogResponse } | undefined) => {
       if (!oldData) return oldData;
 


### PR DESCRIPTION
### 변경 사항
- queryKey 객체 형태로 변경 및 엔티티에 따라 5개 쿼리키로 분리
  - RECIPE_QUERY_KEY
  - FEED_QUERY_KEY
  - CHAT_QUERY_KEY
  - USER_QUERY_KEY
  - FOOD_QUERY_KEY
- id가 이미 `number` 타입임에도 `Number(id)`로 불필요한 형변환하는 코드 삭제
- `invalidateQueries`를 하고 있음에도 `refetchQueries`를 실행하는 코드 삭제
- `boardId` → `logId`로 변수명 통일

### 해결
- 캐싱 문제 해결
  - 레시피 상세 북마크 버튼과 내가 저장한 레시피 목록이 동기화되지 않는 버그 수정
  - 레시피 정보 수정 시 레시피 목록에는 반영되지 않는 버그 수정
  - 장보기 버튼 클릭 시 장보기 목록에 반영되지 않는 버그 수정