### PR TITLE
fix: search food api cursor 방식으로 변경

### DIFF
--- a/src/app/(services)/home/food-search.tsx
+++ b/src/app/(services)/home/food-search.tsx
@@ -35,7 +35,7 @@ const FoodsSearch = ({ selectedFoods, setSelectedFoods }: IFoodsSearchProps) => 
     isFetching,
   } = useSearchFood({
     search: keyword,
-    page: 0,
+    cursor: 0,
   });
 
   return (

--- a/src/app/(services)/recipe/write/ingredient-form.tsx
+++ b/src/app/(services)/recipe/write/ingredient-form.tsx
@@ -25,7 +25,7 @@ const IngredientForm = () => {
 
   const { data, hasNextPage, fetchNextPage, isFetching } = useSearchFood({
     search: keyword,
-    page: 0,
+    cursor: 0,
   });
 
   const foodList = data?.foods.map((food) => ({ id: food.id, title: food.foodName }));

--- a/src/components/molecules/foods-search/FoodsSearch.tsx
+++ b/src/components/molecules/foods-search/FoodsSearch.tsx
@@ -34,7 +34,7 @@ const FoodsSearch = ({
 
   const { data, isFetching } = useSearchFood({
     search: keyword,
-    page: 0,
+    cursor: 0,
   });
 
   const foodList = data?.foods.map((food) => ({ id: food.id, title: food.foodName }));

--- a/src/hooks/queries/food.hooks.ts
+++ b/src/hooks/queries/food.hooks.ts
@@ -7,10 +7,9 @@ import { ISearchFoodParams } from '@/types/api';
 export function useSearchFood(params: ISearchFoodParams) {
   return useInfiniteQuery({
     queryKey: FOOD_QUERY_KEY.SEARCH_WITH_PARAMS(params),
-    queryFn: async ({ pageParam }) => await searchFood({ ...params, page: pageParam }),
-    initialPageParam: params.page,
-    getNextPageParam: (lastPage, _, pageParam) =>
-      lastPage.data.hasNext ? pageParam + 1 : undefined,
+    queryFn: async ({ pageParam }) => await searchFood({ ...params, cursor: pageParam }),
+    initialPageParam: params.cursor,
+    getNextPageParam: (lastPage) => (lastPage.data.hasNext ? lastPage.data.nextCursor : undefined),
     select: (response) => {
       return {
         foods: response.pages.flatMap((page) => page.data.foods),

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -11,6 +11,10 @@ export interface PaginationData {
   hasNext: boolean;
 }
 
+export interface CursorPaginationData extends PaginationData {
+  nextCursor: number;
+}
+
 export type TUserData = {
   id: number;
   userName: string;
@@ -242,10 +246,10 @@ export interface IRecipeProcessResponse {
 // food
 export interface ISearchFoodParams {
   search?: string;
-  page: number;
+  cursor: number;
 }
 
-export interface ISearchFoodResponse extends PaginationData {
+export interface ISearchFoodResponse extends CursorPaginationData {
   foods: IFood[];
 }
 


### PR DESCRIPTION
음식 검색 API의 페이지네이션 방식이 `offset`에서 `cursor`로 변경되어 대응 개발 완료하였습니다.